### PR TITLE
Fixed c++17 version name in kernel file

### DIFF
--- a/tools/Jupyter/kernel/cling-c++17/kernel.json
+++ b/tools/Jupyter/kernel/cling-c++17/kernel.json
@@ -4,6 +4,6 @@
       "jupyter-cling-kernel",
       "-f",
       "{connection_file}",
-      "--std=c++1z"
+      "--std=c++17"
   ]
 }


### PR DESCRIPTION
I encountered the following error and the change fixed it 

Nov 22 22:37:47 thesis jupyter[2811]: [I 22:37:47.646 NotebookApp] The Jupyter Notebook is running at: http://0.0.0.0:8888/
Nov 22 22:37:47 thesis jupyter[2811]: [I 22:37:47.646 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
Nov 22 22:38:20 thesis jupyter[2811]: [I 22:38:20.303 NotebookApp] Kernel started: e416bf37-4f24-4aee-8e25-45c6fbbb85e6
Nov 22 22:38:21 thesis jupyter[2811]: [ClingKernelApp] CRITICAL | Bad config encountered during initialization:
Nov 22 22:38:21 thesis jupyter[2811]: [ClingKernelApp] CRITICAL | The 'std' trait of a ClingKernel instance must be any of ['c++11', 'c++14', 'c++17'], but a value of 'c++1z' <class 'str'> was specified.
Nov 22 22:38:23 thesis jupyter[2811]: [I 22:38:23.308 NotebookApp] KernelRestarter: restarting kernel (1/5)
Nov 22 22:38:24 thesis jupyter[2811]: [ClingKernelApp] CRITICAL | Bad config encountered during initialization:
Nov 22 22:38:24 thesis jupyter[2811]: [ClingKernelApp] CRITICAL | The 'std' trait of a ClingKernel instance must be any of ['c++11', 'c++14', 'c++17'], but a value of 'c++1z' <class 'str'> was specified.
Nov 22 22:38:26 thesis jupyter[2811]: [I 22:38:26.326 NotebookApp] KernelRestarter: restarting kernel (2/5)
Nov 22 22:38:27 thesis jupyter[2811]: [ClingKernelApp] CRITICAL | Bad config encountered during initialization:
Nov 22 22:38:27 thesis jupyter[2811]: [ClingKernelApp] CRITICAL | The 'std' trait of a ClingKernel instance must be any of ['c++11', 'c++14', 'c++17'], but a value of 'c++1z' <class 'str'> was specified.
Nov 22 22:38:29 thesis jupyter[2811]: [I 22:38:29.332 NotebookApp] KernelRestarter: restarting kernel (3/5)
Nov 22 22:38:30 thesis jupyter[2811]: [W 22:38:30.348 NotebookApp] Timeout waiting for kernel_info reply from e416bf37-4f24-4aee-8e25-45c6fbbb85e6
Nov 22 22:38:30 thesis jupyter[2811]: [I 22:38:30.365 NotebookApp] New terminal with specified name: 1
Nov 22 22:38:30 thesis jupyter[2811]: [ClingKernelApp] CRITICAL | Bad config encountered during initialization:
Nov 22 22:38:30 thesis jupyter[2811]: [ClingKernelApp] CRITICAL | The 'std' trait of a ClingKernel instance must be any of ['c++11', 'c++14', 'c++17'], but a value of 'c++1z' <class 'str'> was specified.
Nov 22 22:38:32 thesis jupyter[2811]: [I 22:38:32.338 NotebookApp] KernelRestarter: restarting kernel (4/5)
Nov 22 22:38:32 thesis jupyter[2811]: WARNING:root:kernel e416bf37-4f24-4aee-8e25-45c6fbbb85e6 restarted
Nov 22 22:38:32 thesis jupyter[2811]: [W 22:38:32.664 NotebookApp] Session not found: session_id='19509685-b888-480b-897b-be2cc8fed1cc'
Nov 22 22:38:32 thesis jupyter[2811]: [W 22:38:32.665 NotebookApp] 404 DELETE /api/sessions/19509685-b888-480b-897b-be2cc8fed1cc (192.168.0.24) 3.67ms referer=http://192.168.0.31:8888/notebooks/Untitled.ipynb?kernel_name=cling-c++17
Nov 22 22:38:33 thesis jupyter[2811]: [ClingKernelApp] CRITICAL | Bad config encountered during initialization:
Nov 22 22:38:33 thesis jupyter[2811]: [ClingKernelApp] CRITICAL | The 'std' trait of a ClingKernel instance must be any of ['c++11', 'c++14', 'c++17'], but a value of 'c++1z' <class 'str'> was specified.
Nov 22 22:38:35 thesis jupyter[2811]: [W 22:38:35.349 NotebookApp] KernelRestarter: restart failed
Nov 22 22:38:35 thesis jupyter[2811]: [W 22:38:35.350 NotebookApp] Kernel e416bf37-4f24-4aee-8e25-45c6fbbb85e6 died, removing from map.
Nov 22 22:38:35 thesis jupyter[2811]: ERROR:root:kernel e416bf37-4f24-4aee-8e25-45c6fbbb85e6 restarted failed!
Nov 22 22:38:35 thesis jupyter[2811]: ERROR:root:kernel e416bf37-4f24-4aee-8e25-45c6fbbb85e6 restarted failed!
Nov 22 22:38:35 thesis jupyter[2811]: [W 22:38:35.368 NotebookApp] Kernel deleted before session
Nov 22 22:38:35 thesis jupyter[2811]: [W 22:38:35.369 NotebookApp] 410 DELETE /api/sessions/ff344691-8fd6-4207-902e-01c944bdf7ae (192.168.0.24) 2.13ms referer=http://192.168.0.31:8888/notebooks/Untitled.ipynb